### PR TITLE
fix: update postal-mime to 2.7.3 and add dev branch to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
     branches: [main]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "postal-mime": "^2.4.1",
+        "postal-mime": "^2.7.3",
         "turndown": "^7.2.0"
       },
       "devDependencies": {
@@ -248,8 +248,7 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20251223.0.tgz",
       "integrity": "sha512-r7oxkFjbMcmzhIrzjXaiJlGFDmmeu3+GlwkLlZbUxVWrXHTCkvqu+DrWnNmF6xZEf9j+2/PpuKIS21J522xhJA==",
       "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1721,7 +1720,6 @@
       "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "pathe": "^2.0.3",
@@ -1737,7 +1735,6 @@
       "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
         "magic-string": "^0.30.17",
@@ -2592,7 +2589,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2601,9 +2597,9 @@
       }
     },
     "node_modules/postal-mime": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.1.tgz",
-      "integrity": "sha512-0VslL0CLSV7PBmglwWR8eCGC5fgsdVictjOG4PEA+vvA0+QJF5SC0tV018CbvAcW4XbpbMIJNd91Dt8vTa9kbA==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.3.tgz",
+      "integrity": "sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw==",
       "license": "MIT-0"
     },
     "node_modules/postcss": {
@@ -3071,7 +3067,6 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -3082,7 +3077,6 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3665,7 +3659,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Mark Riechers",
   "license": "MIT",
   "dependencies": {
-    "postal-mime": "^2.4.1",
+    "postal-mime": "^2.7.3",
     "turndown": "^7.2.0"
   },
   "devDependencies": {

--- a/src/test-utils/email-fixtures.ts
+++ b/src/test-utils/email-fixtures.ts
@@ -15,10 +15,10 @@ interface EmailFixtureOptions {
 }
 
 /**
- * Create a Header object with required originalKey property
+ * Create a Header object matching the postal-mime Header type
  */
 function createHeader(key: string, value: string): Header {
-  return { key: key.toLowerCase(), originalKey: key, value };
+  return { key: key.toLowerCase(), value };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Updates `postal-mime` from 2.7.1 to 2.7.3 (fixes Dependabot PR #1 typecheck failure)
- Removes `originalKey` from test fixture `createHeader()` to match corrected Header type
- Adds `dev` branch to CI push triggers (deploy still gated to `main` only)

## Test plan
- [x] All 63 tests pass locally with postal-mime 2.7.3
- [x] Typecheck clean
- [ ] CI passes on this PR

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)