### PR TITLE
feat: replace newsletter HTML conversion with summary + link approach

### DIFF
--- a/src/test-utils/email-fixtures.ts
+++ b/src/test-utils/email-fixtures.ts
@@ -133,6 +133,7 @@ export function createParsedEmail(overrides: Partial<{
   source: 'gmail' | 'outlook' | 'icloud' | 'unknown';
   isNewsletter: boolean;
   newsletterName: string;
+  viewInBrowserUrl: string | null;
 }> = {}) {
   return {
     messageId: overrides.messageId || 'test-message-id',
@@ -144,5 +145,6 @@ export function createParsedEmail(overrides: Partial<{
     attachments: [],
     isNewsletter: overrides.isNewsletter ?? false,
     newsletterName: overrides.newsletterName ?? '',
+    viewInBrowserUrl: overrides.viewInBrowserUrl ?? null,
   };
 }


### PR DESCRIPTION
Newsletters render poorly in both Obsidian and Readwise because HTML-to-
markdown is inherently lossy for complex email layouts. Instead of converting
the full HTML body, newsletter notes now contain:

- A prominent "view in browser" link (extracted from the email HTML)
- A short plain-text excerpt for scanning/searching
- Clean metadata in frontmatter

This removes the newsletter-specific Turndown service (layout table
extraction, tracker pixel stripping, CTA button normalization, footer
stripping) since the HTML body is no longer converted to markdown.

Changes:
- Add extractViewInBrowserUrl() to find "view in browser" links in HTML
- Add extractNewsletterExcerpt() for plain-text excerpt with footer cleanup
- Add viewInBrowserUrl field to ParsedEmail
- Rewrite generateNewsletterMarkdown() with summary+link template
- Change newsletter status field from "unprocessed" to "unread"
- Remove newsletterTurndownService and all its custom rules
- Remove convertNewsletterBodyToMarkdown() and stripUnsubscribeFooter()
- Update and expand tests (82 passing)

https://claude.ai/code/session_01RnQGY68wpSKffjh8HTCPTf