### PR TITLE
feat: include attachment wikilinks in agent message notes

### DIFF
--- a/src/test-utils/email-fixtures.ts
+++ b/src/test-utils/email-fixtures.ts
@@ -133,6 +133,7 @@ export function createParsedEmail(overrides: Partial<{
   source: 'gmail' | 'outlook' | 'icloud' | 'unknown';
   isNewsletter: boolean;
   newsletterName: string;
+  attachments: Email['attachments'];
 }> = {}) {
   return {
     messageId: overrides.messageId || 'test-message-id',
@@ -141,7 +142,7 @@ export function createParsedEmail(overrides: Partial<{
     date: overrides.date || new Date('2025-01-15T10:30:00Z'),
     body: overrides.body || 'Test email body content',
     source: overrides.source || 'unknown' as const,
-    attachments: [],
+    attachments: overrides.attachments ?? [],
     isNewsletter: overrides.isNewsletter ?? false,
     newsletterName: overrides.newsletterName ?? '',
   };

--- a/src/worker.test.ts
+++ b/src/worker.test.ts
@@ -549,6 +549,47 @@ describe('generateAgentMessageMarkdown', () => {
     const markdown = generateAgentMessageMarkdown(email);
     expect(markdown).toContain('subject: "Task: Do this thing"');
   });
+
+  it('includes attachment wikilinks when attachments are present', () => {
+    const email = createParsedEmail({
+      messageId: 'agent-att-123',
+      attachments: [
+        {
+          filename: 'report.pdf',
+          mimeType: 'application/pdf',
+          content: new ArrayBuffer(0),
+          disposition: 'attachment' as const,
+          related: false,
+          contentId: '',
+        },
+        {
+          filename: 'screenshot.png',
+          mimeType: 'image/png',
+          content: new ArrayBuffer(0),
+          disposition: 'attachment' as const,
+          related: false,
+          contentId: '',
+        },
+      ],
+    });
+
+    const markdown = generateAgentMessageMarkdown(email);
+
+    expect(markdown).toContain('## Attachments');
+    expect(markdown).toContain('![[_attachments/agent-att-123/report.pdf]]');
+    expect(markdown).toContain('![[_attachments/agent-att-123/screenshot.png]]');
+  });
+
+  it('omits attachments section when no attachments', () => {
+    const email = createParsedEmail({
+      messageId: 'agent-no-att',
+    });
+
+    const markdown = generateAgentMessageMarkdown(email);
+
+    expect(markdown).not.toContain('## Attachments');
+    expect(markdown).not.toContain('![[');
+  });
 });
 
 describe('generateAgentMessageFilename', () => {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -494,6 +494,23 @@ export function generateAgentMessageMarkdown(email: ParsedEmail): string {
   const createdDate = formatDate(email.date);
   const fullDate = formatDateLong(email.date);
 
+  let attachmentsSection = '';
+  if (email.attachments && email.attachments.length > 0) {
+    const attachmentLinks = email.attachments
+      .map(att => {
+        const safeFilename = sanitizeAttachmentFilename(att.filename || 'untitled');
+        const attachmentPath = `_attachments/${email.messageId}/${safeFilename}`;
+        return `- ![[${attachmentPath}]]`;
+      })
+      .join('\n');
+    attachmentsSection = `---
+## Attachments
+
+${attachmentLinks}
+
+`;
+  }
+
   return `---
 tags:
   - agent-message
@@ -513,7 +530,8 @@ status: pending
 ---
 
 ${email.body}
-`;
+
+${attachmentsSection}`;
 }
 
 /**


### PR DESCRIPTION
Emails to claude@ already had their attachments saved to R2, but the generated markdown note didn't reference them. Agents need access to attachments (PDFs, images, etc.) to process forwarded emails properly.

https://claude.ai/code/session_01Wvway6nPZiVUt8E4PfHyH3