### PR TITLE
Refactor createParsedEmail to use ParsedEmail type

### DIFF
--- a/src/test-utils/email-fixtures.ts
+++ b/src/test-utils/email-fixtures.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Email, Header } from 'postal-mime';
+import type { ParsedEmail } from '../worker';
 
 interface EmailFixtureOptions {
   from?: { name?: string; address: string };
@@ -124,17 +125,7 @@ export function createAgentMessageEmail(options: EmailFixtureOptions = {}): Emai
 /**
  * Create a ParsedEmail object for testing generateMarkdown/generateFilename
  */
-export function createParsedEmail(overrides: Partial<{
-  messageId: string;
-  from: { name: string; email: string };
-  subject: string;
-  date: Date;
-  body: string;
-  source: 'gmail' | 'outlook' | 'icloud' | 'unknown';
-  isNewsletter: boolean;
-  newsletterName: string;
-  viewInBrowserUrl: string | null;
-}> = {}) {
+export function createParsedEmail(overrides: Partial<ParsedEmail> = {}) {
   return {
     messageId: overrides.messageId || 'test-message-id',
     from: overrides.from || { name: 'Test Sender', email: 'test@example.com' },


### PR DESCRIPTION
## Summary
Simplified the `createParsedEmail` test fixture function by replacing its inline type definition with the actual `ParsedEmail` type imported from the worker module.

## Changes
- Imported `ParsedEmail` type from `../worker`
- Replaced the verbose inline `Partial<{ ... }>` type annotation with `Partial<ParsedEmail>`
- Maintains identical functionality while improving type consistency and maintainability

## Benefits
- Eliminates type duplication between the fixture and the actual type definition
- Ensures the test fixture always matches the real `ParsedEmail` type
- Reduces code verbosity and improves readability
- Single source of truth for the `ParsedEmail` structure

https://claude.ai/code/session_01WovNz7jFLDVGRUXsMFTN8g