### PR TITLE
Improve newsletter excerpt extraction with 2000 char limit

### DIFF
--- a/src/worker.test.ts
+++ b/src/worker.test.ts
@@ -424,6 +424,22 @@ describe('extractNewsletterExcerpt', () => {
     const text = 'Paragraph one.\n\n\n\n\nParagraph two.';
     expect(extractNewsletterExcerpt(text)).toBe('Paragraph one.\n\nParagraph two.');
   });
+
+  it('uses 2000 char default limit for comprehensive excerpts', () => {
+    // A 1500-char text should be kept in full with the new default
+    const text = 'A'.repeat(1500);
+    expect(extractNewsletterExcerpt(text)).toBe(text);
+  });
+
+  it('truncates text over 2000 chars by default', () => {
+    const text = 'A'.repeat(2500);
+    expect(extractNewsletterExcerpt(text)).toBe('A'.repeat(2000) + '...');
+  });
+
+  it('preserves "View in browser" text (not stripped as boilerplate)', () => {
+    const text = 'View in browser\n\nHere is the newsletter content.';
+    expect(extractNewsletterExcerpt(text)).toBe(text);
+  });
 });
 
 describe('generateNewsletterMarkdown', () => {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -216,15 +216,16 @@ async function parseEmail(message: ForwardableEmailMessage, route: EmailRoute = 
   //   - other routes → not a newsletter
   const newsletter = route === 'newsletter' || (route === 'inbox' && isNewsletter(email));
 
-  // For newsletters: extract "view in browser" link and use a short excerpt
-  // instead of the full (lossy) HTML-to-Markdown conversion.
+  // For newsletters: convert HTML to Markdown via Turndown then extract a
+  // generous excerpt (2000 chars) and strip boilerplate footers.
   // For other emails: full Turndown conversion as before.
   let body: string;
   let viewInBrowserUrl: string | null = null;
 
   if (newsletter) {
     viewInBrowserUrl = email.html ? extractViewInBrowserUrl(email.html) : null;
-    body = extractNewsletterExcerpt(email.text || '');
+    const fullBody = convertBodyToMarkdown(email);
+    body = extractNewsletterExcerpt(fullBody);
   } else {
     body = convertBodyToMarkdown(email);
   }
@@ -339,18 +340,17 @@ export function extractViewInBrowserUrl(html: string): string | null {
 }
 
 /**
- * Extract a short excerpt from the plain-text email body.
+ * Extract a comprehensive excerpt from the newsletter body.
  * Strips footer/unsubscribe boilerplate and truncates at a sentence boundary.
  */
-export function extractNewsletterExcerpt(text: string, maxLength: number = 500): string {
+export function extractNewsletterExcerpt(text: string, maxLength: number = 2000): string {
   if (!text) return '';
 
   // Strip common footer/unsubscribe boilerplate
   let cleaned = text
     .replace(/You(?:'re| are) receiving this[\s\S]*/i, '')
     .replace(/Unsubscribe[\s\S]*/i, '')
-    .replace(/Update your preferences[\s\S]*/i, '')
-    .replace(/View in browser[\s\S]*/i, '');
+    .replace(/Update your preferences[\s\S]*/i, '');
 
   // Normalize whitespace
   cleaned = cleaned.replace(/\n{3,}/g, '\n\n').trim();


### PR DESCRIPTION
## Summary
This PR enhances newsletter excerpt extraction by increasing the default character limit from 500 to 2000 characters, allowing for more comprehensive newsletter previews while still maintaining reasonable truncation for very long emails.

## Key Changes
- **Increased default excerpt limit**: Changed `maxLength` parameter default from 500 to 2000 characters in `extractNewsletterExcerpt()`
- **Improved newsletter body processing**: Now converts HTML to Markdown via Turndown before extracting excerpts, providing better formatting consistency
- **Refined boilerplate stripping**: Removed "View in browser" from the list of stripped patterns, as it's now preserved as part of the newsletter content
- **Updated documentation**: Clarified function comments to reflect the new "comprehensive excerpt" approach

## Implementation Details
- The function still strips common footer boilerplate like "You're receiving this", "Unsubscribe", and "Update your preferences"
- Whitespace normalization (collapsing 3+ newlines to 2) is preserved to maintain readability
- Text exceeding 2000 characters is truncated with "..." appended
- Added test coverage for the new behavior:
  - Verifies 1500-char text is kept in full
  - Confirms 2500-char text is truncated to 2000 chars
  - Ensures "View in browser" text is preserved

https://claude.ai/code/session_01EQD2AcaJge1zk6cdB8ethK