### PR TITLE
feat: newsletter digests, attachment URLs, agent inbox triage

### DIFF
--- a/src/test-utils/email-fixtures.ts
+++ b/src/test-utils/email-fixtures.ts
@@ -131,11 +131,14 @@ export function createParsedEmail(overrides: Partial<ParsedEmail> = {}) {
     from: overrides.from || { name: 'Test Sender', email: 'test@example.com' },
     subject: overrides.subject || 'Test Subject',
     date: overrides.date || new Date('2025-01-15T10:30:00Z'),
-    body: overrides.body || 'Test email body content',
+    body: overrides.body ?? 'Test email body content',
+    rawHtml: overrides.rawHtml,
     source: overrides.source || 'unknown' as const,
     attachments: overrides.attachments ?? [],
+    attachmentUrls: overrides.attachmentUrls ?? [],
     isNewsletter: overrides.isNewsletter ?? false,
     newsletterName: overrides.newsletterName ?? '',
     viewInBrowserUrl: overrides.viewInBrowserUrl ?? null,
+    topic: overrides.topic,
   };
 }

--- a/src/worker.test.ts
+++ b/src/worker.test.ts
@@ -13,11 +13,16 @@ import {
   generateMarkdown,
   detectEmailSource,
   isNewsletter,
+  isImageMimeType,
+  buildAttachmentUrl,
   extractNewsletterName,
   extractViewInBrowserUrl,
   extractNewsletterExcerpt,
-  generateNewsletterMarkdown,
-  generateNewsletterFilename,
+  generateDigestFilename,
+  generateNewsletterHtmlPath,
+  generateDigestEntry,
+  generateDigestMarkdown,
+  parseDigestMarkdown,
   extractRoute,
   generateAgentMessageMarkdown,
   generateAgentMessageFilename,
@@ -442,155 +447,230 @@ describe('extractNewsletterExcerpt', () => {
   });
 });
 
-describe('generateNewsletterMarkdown', () => {
-  it('generates newsletter markdown with correct frontmatter', () => {
-    const email = createParsedEmail({
-      messageId: 'nl-123',
-      from: { name: 'Design Weekly', email: 'hello@designweekly.com' },
-      subject: 'Issue #47: CSS Updates',
-      date: new Date('2026-02-03T10:00:00Z'),
-      body: 'Newsletter excerpt here',
-      source: 'unknown',
-      isNewsletter: true,
-      newsletterName: 'Design Weekly',
-      viewInBrowserUrl: 'https://designweekly.com/view/47',
-    });
+// --- Newsletter Digest ---
 
-    const markdown = generateNewsletterMarkdown(email);
-
-    expect(markdown).toContain('tags:');
-    expect(markdown).toContain('- newsletter');
-    expect(markdown).not.toContain('- email-task');
-    expect(markdown).toContain('newsletter_name: Design Weekly');
-    expect(markdown).toContain('status: unread');
-    expect(markdown).toContain('from: hello@designweekly.com');
-    expect(markdown).toContain('email_id: nl-123');
+describe('generateDigestFilename', () => {
+  it('generates correct path format', () => {
+    const date = new Date('2026-02-03T10:00:00Z');
+    expect(generateDigestFilename(date, '0 - INBOX/NEWSLETTERS'))
+      .toBe('0 - INBOX/NEWSLETTERS/2026-02-03 - Newsletter Digest.md');
   });
 
-  it('includes "view in browser" link when available', () => {
-    const email = createParsedEmail({
-      isNewsletter: true,
-      newsletterName: 'Test Newsletter',
-      viewInBrowserUrl: 'https://example.com/view/123',
-    });
+  it('uses provided folder', () => {
+    const date = new Date('2026-01-15T10:00:00Z');
+    expect(generateDigestFilename(date, 'CUSTOM'))
+      .toBe('CUSTOM/2026-01-15 - Newsletter Digest.md');
+  });
+});
 
-    const markdown = generateNewsletterMarkdown(email);
-
-    expect(markdown).toContain('[Read full newsletter →](https://example.com/view/123)');
+describe('generateNewsletterHtmlPath', () => {
+  it('generates correct path with slug', () => {
+    const date = new Date('2026-02-03T10:00:00Z');
+    const path = generateNewsletterHtmlPath(date, 'Design Weekly', 'Issue #47');
+    expect(path).toBe('_newsletter-html/2026-02-03/design-weekly-issue-47.html');
   });
 
-  it('shows fallback message when no view-in-browser URL', () => {
-    const email = createParsedEmail({
-      isNewsletter: true,
-      newsletterName: 'Test Newsletter',
-      viewInBrowserUrl: null,
-    });
-
-    const markdown = generateNewsletterMarkdown(email);
-
-    expect(markdown).toContain('No "view in browser" link found');
+  it('handles special characters in slug', () => {
+    const date = new Date('2026-02-03T10:00:00Z');
+    const path = generateNewsletterHtmlPath(date, 'The Morning Brew ☕', 'What\'s New? #100!');
+    expect(path).toMatch(/^_newsletter-html\/2026-02-03\/[a-z0-9-]+\.html$/);
+    expect(path).not.toContain('☕');
+    expect(path).not.toContain("'");
   });
 
-  it('does NOT include tasks section', () => {
-    const email = createParsedEmail({
-      isNewsletter: true,
-      newsletterName: 'Test Newsletter',
-    });
-
-    const markdown = generateNewsletterMarkdown(email);
-
-    expect(markdown).not.toContain('## Tasks in this note');
-    expect(markdown).not.toContain('- [ ] Review and process this email');
+  it('limits slug length to 80 chars', () => {
+    const date = new Date('2026-02-03T10:00:00Z');
+    const path = generateNewsletterHtmlPath(date, 'A'.repeat(50), 'B'.repeat(50));
+    const slug = path.split('/').pop()!.replace('.html', '');
+    expect(slug.length).toBeLessThanOrEqual(80);
   });
 
-  it('uses newsletter name in heading', () => {
+  it('strips leading and trailing hyphens from slug', () => {
+    const date = new Date('2026-02-03T10:00:00Z');
+    const path = generateNewsletterHtmlPath(date, '---Test---', '!!!Subject!!!');
+    const slug = path.split('/').pop()!.replace('.html', '');
+    expect(slug).not.toMatch(/^-/);
+    expect(slug).not.toMatch(/-$/);
+  });
+});
+
+describe('generateDigestEntry', () => {
+  it('renders entry with URL and excerpt', () => {
     const email = createParsedEmail({
       from: { name: 'Design Weekly', email: 'hello@designweekly.com' },
       subject: 'Issue #47',
       isNewsletter: true,
       newsletterName: 'Design Weekly',
+      body: 'CSS updates this week.',
     });
 
-    const markdown = generateNewsletterMarkdown(email);
-
-    expect(markdown).toContain('## Design Weekly — Issue #47');
+    const entry = generateDigestEntry(email, 'https://example.com/view');
+    expect(entry).toContain('### Design Weekly — Issue #47');
+    expect(entry).toContain('**From:** hello@designweekly.com');
+    expect(entry).toContain('[Read full newsletter →](https://example.com/view)');
+    expect(entry).toContain('> CSS updates this week.');
   });
 
-  it('escapes YAML-problematic newsletter names', () => {
+  it('renders entry without URL', () => {
     const email = createParsedEmail({
-      isNewsletter: true,
-      newsletterName: 'News: Daily Update',
-    });
-
-    const markdown = generateNewsletterMarkdown(email);
-    expect(markdown).toContain('newsletter_name: "News: Daily Update"');
-  });
-
-  it('includes body excerpt after separator', () => {
-    const email = createParsedEmail({
-      isNewsletter: true,
       newsletterName: 'Test',
-      body: 'This is the newsletter excerpt content.',
-      viewInBrowserUrl: 'https://example.com/view',
+      subject: 'Hello',
+      body: 'Content here.',
     });
 
-    const markdown = generateNewsletterMarkdown(email);
-    expect(markdown).toContain('This is the newsletter excerpt content.');
+    const entry = generateDigestEntry(email, null);
+    expect(entry).not.toContain('[Read full newsletter');
+    expect(entry).toContain('> Content here.');
+  });
+
+  it('renders entry without body', () => {
+    const email = createParsedEmail({
+      newsletterName: 'Test',
+      subject: 'Hello',
+      body: '',
+    });
+
+    const entry = generateDigestEntry(email, 'https://example.com');
+    expect(entry).toContain('### Test — Hello');
+    expect(entry).toContain('[Read full newsletter →]');
+    // No blockquote lines (lines starting with "> ")
+    expect(entry).not.toMatch(/^> /m);
+  });
+
+  it('formats multi-line body as blockquote', () => {
+    const email = createParsedEmail({
+      newsletterName: 'Test',
+      subject: 'Hello',
+      body: 'Line one\nLine two\nLine three',
+    });
+
+    const entry = generateDigestEntry(email, null);
+    expect(entry).toContain('> Line one\n> Line two\n> Line three');
+  });
+
+  it('falls back to from.name when newsletterName is empty', () => {
+    const email = createParsedEmail({
+      from: { name: 'Fallback Name', email: 'fallback@test.com' },
+      subject: 'Subject',
+      newsletterName: '',
+    });
+
+    const entry = generateDigestEntry(email, null);
+    expect(entry).toContain('### Fallback Name — Subject');
   });
 });
 
-describe('generateNewsletterFilename', () => {
-  it('generates newsletter filename with newsletter name prefix', () => {
-    const email = createParsedEmail({
-      from: { name: 'Design Weekly', email: 'hello@designweekly.com' },
-      subject: 'Issue #47: CSS Updates',
-      date: new Date('2026-02-03T10:00:00Z'),
-      isNewsletter: true,
-      newsletterName: 'Design Weekly',
-    });
+describe('generateDigestMarkdown', () => {
+  it('generates digest with single entry', () => {
+    const date = new Date('2026-02-03T10:00:00Z');
+    const entries = ['### Test — Subject\n**From:** a@b.com'];
+    const emailIds = ['id-1'];
 
-    const filename = generateNewsletterFilename(email, '0 - INBOX/NEWSLETTERS');
-    expect(filename).toBe('0 - INBOX/NEWSLETTERS/2026-02-03 - Design Weekly - Issue #47- CSS Updates.md');
+    const md = generateDigestMarkdown(date, entries, emailIds);
+    expect(md).toContain('tags:');
+    expect(md).toContain('- newsletter');
+    expect(md).toContain('- digest');
+    expect(md).toContain('created: 2026-02-03');
+    expect(md).toContain('newsletter_count: 1');
+    expect(md).toContain('  - id-1');
+    expect(md).toContain('# Newsletter Digest — 2026-02-03');
+    expect(md).toContain('### Test — Subject');
   });
 
-  it('sanitizes unsafe characters in newsletter name', () => {
-    const email = createParsedEmail({
-      subject: 'Test',
-      date: new Date('2026-02-03T10:00:00Z'),
-      isNewsletter: true,
-      newsletterName: 'News/Letter:Special',
-    });
+  it('generates digest with multiple entries separated by ---', () => {
+    const date = new Date('2026-02-03T10:00:00Z');
+    const entries = ['### A — Sub1\n**From:** a@b.com', '### B — Sub2\n**From:** c@d.com'];
+    const emailIds = ['id-1', 'id-2'];
 
-    const filename = generateNewsletterFilename(email, 'NEWSLETTERS');
-    expect(filename).not.toContain('/Letter');
-    expect(filename).toContain('News-Letter-Special');
+    const md = generateDigestMarkdown(date, entries, emailIds);
+    expect(md).toContain('newsletter_count: 2');
+    expect(md).toContain('  - id-1');
+    expect(md).toContain('  - id-2');
+    // Entries separated by ---
+    expect(md).toContain('---\n\n### B — Sub2');
   });
 
-  it('truncates long newsletter names', () => {
-    const email = createParsedEmail({
-      subject: 'Short Subject',
-      date: new Date('2026-02-03T10:00:00Z'),
-      isNewsletter: true,
-      newsletterName: 'A'.repeat(80),
-    });
+  it('includes all email IDs in frontmatter', () => {
+    const date = new Date('2026-02-03T10:00:00Z');
+    const md = generateDigestMarkdown(date, ['e1', 'e2', 'e3'], ['a', 'b', 'c']);
+    expect(md).toContain('  - a\n  - b\n  - c');
+  });
+});
 
-    const filename = generateNewsletterFilename(email, 'NL');
-    // Newsletter name should be truncated to 40 chars
-    const namePart = filename.split(' - ')[1];
-    expect(namePart.length).toBeLessThanOrEqual(40);
+describe('parseDigestMarkdown', () => {
+  it('extracts entries and email IDs', () => {
+    const md = `---
+tags:
+  - newsletter
+  - digest
+created: 2026-02-03
+newsletter_count: 2
+email_ids:
+  - id-1
+  - id-2
+---
+
+# Newsletter Digest — 2026-02-03
+
+### A — Sub1
+**From:** a@b.com
+
+---
+
+### B — Sub2
+**From:** c@d.com
+`;
+
+    const result = parseDigestMarkdown(md);
+    expect(result.emailIds).toEqual(['id-1', 'id-2']);
+    expect(result.entries).toHaveLength(2);
+    expect(result.entries[0]).toContain('### A — Sub1');
+    expect(result.entries[1]).toContain('### B — Sub2');
   });
 
-  it('strips FWD prefix from subject', () => {
-    const email = createParsedEmail({
-      subject: 'Fwd: Weekly Digest',
-      date: new Date('2026-02-03T10:00:00Z'),
-      isNewsletter: true,
-      newsletterName: 'Tech News',
-    });
+  it('handles single entry digest', () => {
+    const md = `---
+tags:
+  - newsletter
+  - digest
+created: 2026-02-03
+newsletter_count: 1
+email_ids:
+  - id-1
+---
 
-    const filename = generateNewsletterFilename(email, 'NL');
-    expect(filename).not.toContain('Fwd:');
-    expect(filename).toContain('Weekly Digest');
+# Newsletter Digest — 2026-02-03
+
+### A — Sub1
+**From:** a@b.com
+`;
+
+    const result = parseDigestMarkdown(md);
+    expect(result.emailIds).toEqual(['id-1']);
+    expect(result.entries).toHaveLength(1);
+  });
+
+  it('round-trips with generateDigestMarkdown', () => {
+    const date = new Date('2026-02-03T10:00:00Z');
+    const entries = [
+      '### Design Weekly — Issue #47\n**From:** hello@designweekly.com\n[Read full newsletter →](https://example.com)\n\n> Great CSS updates.',
+      '### Morning Brew — Daily\n**From:** crew@brew.com\n\n> Top stories today.',
+    ];
+    const emailIds = ['id-1', 'id-2'];
+
+    const md = generateDigestMarkdown(date, entries, emailIds);
+    const parsed = parseDigestMarkdown(md);
+
+    expect(parsed.emailIds).toEqual(emailIds);
+    expect(parsed.entries).toHaveLength(2);
+    expect(parsed.entries[0]).toContain('### Design Weekly — Issue #47');
+    expect(parsed.entries[1]).toContain('### Morning Brew — Daily');
+  });
+
+  it('handles empty/malformed content gracefully', () => {
+    const result = parseDigestMarkdown('');
+    expect(result.emailIds).toEqual([]);
+    expect(result.entries).toEqual([]);
   });
 });
 
@@ -688,7 +768,7 @@ describe('generateAgentMessageMarkdown', () => {
     expect(markdown).toContain('subject: "Task: Do this thing"');
   });
 
-  it('includes attachment wikilinks when attachments are present', () => {
+  it('includes attachment URLs when attachments are present', () => {
     const email = createParsedEmail({
       messageId: 'agent-att-123',
       attachments: [
@@ -709,13 +789,19 @@ describe('generateAgentMessageMarkdown', () => {
           contentId: '',
         },
       ],
+      attachmentUrls: [
+        'https://worker.example.com/attachment/agent-att-123/report.pdf',
+        'https://worker.example.com/attachment/agent-att-123/screenshot.png',
+      ],
     });
 
     const markdown = generateAgentMessageMarkdown(email);
 
     expect(markdown).toContain('## Attachments');
-    expect(markdown).toContain('![[_attachments/agent-att-123/report.pdf]]');
-    expect(markdown).toContain('![[_attachments/agent-att-123/screenshot.png]]');
+    // PDF = regular link (not image)
+    expect(markdown).toContain('[report.pdf](https://worker.example.com/attachment/agent-att-123/report.pdf)');
+    // PNG = image embed
+    expect(markdown).toContain('![screenshot.png](https://worker.example.com/attachment/agent-att-123/screenshot.png)');
   });
 
   it('omits attachments section when no attachments', () => {
@@ -772,5 +858,110 @@ describe('generateAgentMessageFilename', () => {
     // Agent/ + date + " - " + subject(max 100) + .md
     const subjectPart = filename.split(' - ').slice(1).join(' - ').replace('.md', '');
     expect(subjectPart.length).toBeLessThanOrEqual(100);
+  });
+});
+
+// --- Attachment URL Helpers ---
+
+describe('isImageMimeType', () => {
+  it('returns true for image MIME types', () => {
+    expect(isImageMimeType('image/png')).toBe(true);
+    expect(isImageMimeType('image/jpeg')).toBe(true);
+    expect(isImageMimeType('image/gif')).toBe(true);
+    expect(isImageMimeType('image/webp')).toBe(true);
+    expect(isImageMimeType('image/svg+xml')).toBe(true);
+  });
+
+  it('returns false for non-image MIME types', () => {
+    expect(isImageMimeType('application/pdf')).toBe(false);
+    expect(isImageMimeType('text/plain')).toBe(false);
+    expect(isImageMimeType('application/octet-stream')).toBe(false);
+    expect(isImageMimeType('video/mp4')).toBe(false);
+  });
+});
+
+describe('buildAttachmentUrl', () => {
+  it('returns HTTP URL when WORKER_URL is set', () => {
+    expect(buildAttachmentUrl('https://worker.example.com', 'msg-123', 'file.pdf'))
+      .toBe('https://worker.example.com/attachment/msg-123/file.pdf');
+  });
+
+  it('strips trailing slash from WORKER_URL', () => {
+    expect(buildAttachmentUrl('https://worker.example.com/', 'msg-123', 'file.pdf'))
+      .toBe('https://worker.example.com/attachment/msg-123/file.pdf');
+  });
+
+  it('returns relative path when WORKER_URL is empty', () => {
+    expect(buildAttachmentUrl('', 'msg-123', 'file.pdf'))
+      .toBe('_attachments/msg-123/file.pdf');
+  });
+
+  it('returns relative path when WORKER_URL is undefined', () => {
+    expect(buildAttachmentUrl(undefined, 'msg-123', 'file.pdf'))
+      .toBe('_attachments/msg-123/file.pdf');
+  });
+});
+
+describe('generateMarkdown attachment URLs', () => {
+  it('renders images with ![](url) syntax', () => {
+    const email = createParsedEmail({
+      messageId: 'att-test-1',
+      attachments: [
+        {
+          filename: 'photo.jpg',
+          mimeType: 'image/jpeg',
+          content: new ArrayBuffer(0),
+          disposition: 'attachment' as const,
+          related: false,
+          contentId: '',
+        },
+      ],
+      attachmentUrls: ['https://worker.example.com/attachment/att-test-1/photo.jpg'],
+    });
+
+    const markdown = generateMarkdown(email);
+    expect(markdown).toContain('![photo.jpg](https://worker.example.com/attachment/att-test-1/photo.jpg)');
+  });
+
+  it('renders non-images with [](url) syntax', () => {
+    const email = createParsedEmail({
+      messageId: 'att-test-2',
+      attachments: [
+        {
+          filename: 'document.pdf',
+          mimeType: 'application/pdf',
+          content: new ArrayBuffer(0),
+          disposition: 'attachment' as const,
+          related: false,
+          contentId: '',
+        },
+      ],
+      attachmentUrls: ['https://worker.example.com/attachment/att-test-2/document.pdf'],
+    });
+
+    const markdown = generateMarkdown(email);
+    expect(markdown).toContain('[document.pdf](https://worker.example.com/attachment/att-test-2/document.pdf)');
+    // Should NOT have image prefix
+    expect(markdown).not.toContain('![document.pdf]');
+  });
+
+  it('falls back to relative path when no attachmentUrls', () => {
+    const email = createParsedEmail({
+      messageId: 'att-test-3',
+      attachments: [
+        {
+          filename: 'file.txt',
+          mimeType: 'text/plain',
+          content: new ArrayBuffer(0),
+          disposition: 'attachment' as const,
+          related: false,
+          contentId: '',
+        },
+      ],
+      attachmentUrls: [],
+    });
+
+    const markdown = generateMarkdown(email);
+    expect(markdown).toContain('[file.txt](_attachments/att-test-3/file.txt)');
   });
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,7 @@
 name = "email-to-obsidian"
 main = "src/worker.ts"
 compatibility_date = "2024-01-01"
+workers_dev = true
 
 [triggers]
 crons = ["0 6 * * *"]  # Daily at 6 AM UTC (midnight CST)
@@ -9,8 +10,11 @@ crons = ["0 6 * * *"]  # Daily at 6 AM UTC (midnight CST)
 INBOX_FOLDER = "0 - INBOX"
 NEWSLETTER_FOLDER = "0 - INBOX/NEWSLETTERS"
 AGENT_FOLDER = "0 - INBOX/AGENT MESSAGES"
+WORKER_URL = ""
+ATTACHMENT_RETENTION_DAYS = "90"
 # Personal/infrastructure values stored as Wrangler secrets:
 #   npx wrangler secret put FORWARD_TO
+#   npx wrangler secret put WORKER_URL  (set to https://email-to-obsidian.<subdomain>.workers.dev)
 #   npx wrangler secret put CF_ACCOUNT_ID
 #   npx wrangler secret put CF_ZONE_IDS
 #   npx wrangler secret put CF_ZONE_NAMES


### PR DESCRIPTION
## Summary

- **Newsletter pipeline overhaul**: Daily digest format with topic classification (Tech/Design/Business/News/Culture), excerpt extraction, and R2-hosted HTML fallback served via Worker HTTP endpoint
- **Attachment serving via HTTP URLs**: Replaces Obsidian wikilinks with standard markdown URLs (`![img](url)` / `[file](url)`) served by the Worker's `fetch()` handler, with configurable purge schedule (`ATTACHMENT_RETENTION_DAYS=90`)
- **Agent inbox triage script**: Scheduled Node.js script (`scripts/agent-inbox-triage.mjs`) that enriches `status: pending` agent messages with vault context and Library research via MCP
- **Repo modernization**: Migrated agent knowledge docs to The Library, added MIT license, scrubbed personal data, renamed project references to obsidian-inbox

## What changed

### Worker (`src/worker.ts`)
- `fetch()` handler: serves newsletter HTML at `/newsletter/` and attachments at `/attachment/`
- Newsletter topic detection (`detectNewsletterTopic`) with keyword-based classification
- Daily digest: `appendToDigest()` read-modify-write with dedup, topic-grouped rendering
- `purgeOldAttachments()` cron for R2 storage management
- `buildAttachmentUrl()` / `isImageMimeType()` helpers for URL-based attachment references
- `Env` interface: added `WORKER_URL`, `ATTACHMENT_RETENTION_DAYS`

### Tests (`src/worker.test.ts`)
- 33 → 116 tests covering all new functions
- Attachment assertions updated from wikilink to URL format

### Scripts
- `scripts/agent-inbox-triage.mjs` — MCP-based vault search + Library enrichment
- `scripts/readwise-protect.mjs` / `readwise-restore.mjs` — Readwise archive bulk management
- `scripts/com.obsidian-inbox.agent-triage.plist` — launchd scheduled runs

### Config
- `wrangler.toml`: new env vars, newsletter/agent folder config
- `CLAUDE.md`: updated project docs
- Removed `AGENTS.md`, `knowledge/agents/` (migrated to The Library)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 116 tests passing
- [ ] Deploy and send test email with image + PDF attachment (#18)
- [ ] Verify newsletter digest renders with topic sections
- [ ] Verify attachment URLs load in browser with correct Content-Type
- [ ] Test purge cron via `npm run tail`

🤖 Generated with [Claude Code](https://claude.com/claude-code)